### PR TITLE
STStruct fixes

### DIFF
--- a/STStruct/Nodes/STUShort.cs
+++ b/STStruct/Nodes/STUShort.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+
+namespace PDTools.STStruct.Nodes
+{
+    [DebuggerDisplay("{Value} (UShort)")]
+    public class STUShort : NodeBase
+    {
+        public STUShort(ushort val)
+        {
+            Value = val;
+        }
+
+        public ushort Value { get; set; }
+
+        public override string ToString()
+            => Value.ToString();
+    }
+}

--- a/STStruct/STStruct.cs
+++ b/STStruct/STStruct.cs
@@ -81,8 +81,14 @@ namespace PDTools.STStruct
                 case NodeType.Short:
                     currentNode = new STShort(sr.ReadInt16());
                     break;
+                case NodeType.UShort:
+                    currentNode = new STUShort(sr.ReadUInt16());
+                    break;
                 case NodeType.SByte:
                     currentNode = new STSByte(sr.ReadSByte());
+                    break;
+                case NodeType.UByte:
+                    currentNode = new STByte(sr.ReadByte());
                     break;
                 case NodeType.Int:
                     currentNode = new STInt(sr.ReadInt32());
@@ -198,6 +204,8 @@ namespace PDTools.STStruct
                     bs.WriteByte(@byte.Value); break;
                 case STShort @short:
                     bs.WriteInt16(@short.Value); break;
+                case STUShort @ushort:
+                    bs.WriteUInt16(@ushort.Value); break;
                 case STInt @int:
                     bs.WriteInt32(@int.Value);
                     if (@int.KeyConfigNode != null)


### PR DESCRIPTION
- Fixed an issue with GetField with GT5/GT6 saves where the RootNode is not STObject but STMap
- Fixed an issue with reading GT5/GT6 saves where there's KeyConfigNode oddity
- Fixed an issue with writing GT5/GT6 saves where there's KeyConfigNode oddity
- Fixed an issue with writing the STString type (was being written with 0x00)

Unsure if these are exactly how the game does it but seemed to be working for GT5/GT6 saves.