### PR TITLE
Fix `CELL_GCM_TEXTURE_A8R8G8B8` outputs’ reversed channels

### DIFF
--- a/PDTools.Files/Textures/PS3/PGLUCellTextureInfo.cs
+++ b/PDTools.Files/Textures/PS3/PGLUCellTextureInfo.cs
@@ -339,12 +339,8 @@ public class PGLUCellTextureInfo : PGLUTextureInfo
         // Swap channels for DDS
         if (format == CELL_GCM_TEXTURE_FORMAT.CELL_GCM_TEXTURE_A8R8G8B8 || format == CELL_GCM_TEXTURE_FORMAT.CELL_GCM_TEXTURE_D8R8G8B8)
         {
-            var sp = MemoryMarshal.Cast<byte, uint>(imageData);
             for (var i = 0; i < Width * Height * 4; i += 4)
             {
-                // Swap endian first
-                sp[i / 4] = BinaryPrimitives.ReverseEndianness(sp[i / 4]);
-
                 // Remap channels
                 byte r = imageData[i + (byte)InR];
                 byte g = imageData[i + (byte)InG];


### PR DESCRIPTION
| path | broken | fixed |
| -- | -- | -- |
| `~/projects/gt5p/manual/GB/mage/gt5p/common/hot.dds` | <img width="68" height="72" alt="hot.dds" src="https://github.com/user-attachments/assets/1d678ca7-737c-40cf-87b2-3d36aaa565dd" /> | <img width="68" height="72" alt="hot" src="https://github.com/user-attachments/assets/d5c4fba8-ec1f-43c9-b119-56c9d3a7044c" /> |
| `~/projects/gt5p/arcade/GB/mage/gt5p/icon/icon_dealer.dds` | <img width="220" height="240" alt="icon_dealer.dds" src="https://github.com/user-attachments/assets/edec167c-763e-470f-ac7a-d737f854841f" /> | <img width="220" height="240" alt="icon_dealer" src="https://github.com/user-attachments/assets/003ab7c3-5d65-4b53-af3c-5b5c9e54352e" /> |

`CELL_GCM_TEXTURE_A8R8G8B8` formatted TXS3 files were incorrectly output with their channels in reverse order.

The values of `CELL_GCM_TEXTURE_REMAP_FROM` _looked_ correct to me, so the individual channels were already being read in their intended byte order.

| Channel | CELL_GCM_TEXTURE_A8R8G8B8 | Default values |
| --: | --: | --: |
| InB | 0 | 3 |
| InG | 1 | 2 |
| InR | 2 | 1 |
| InA | 3 | 0 |

I’m unsure what the manual endianness conversion was for, but with it removed `A8R8G8B8` textures exported as expected. I don’t have an example of `CELL_GCM_TEXTURE_D8R8G8B8` so don’t know if I’ve made a regression there 🫠 